### PR TITLE
Cleanup references to `match` in Guidebook

### DIFF
--- a/src/handbook/actions.md
+++ b/src/handbook/actions.md
@@ -10,13 +10,13 @@ weight: 3
 
 ## Description
 
-There are three actions in Eve: `match`, `bind`, and `commit`.
+There are three actions in Eve: `search`, `bind`, and `commit`.
 
-`match` is used when you want to gather records from one or more databases. These records are called "supporting records", because they are used as a basis for bound or committed records.
+`search` is used when you want to gather records from one or more databases. These records are called "supporting records", because they are used as a basis for bound or committed records.
 
-`bind` and `commit` actions are used when you want to update records in one or more databases, but they differ in the way the updates are performed. 
+`bind` and `commit` actions are used when you want to update records in one or more databases, but they differ in the way the updates are performed.
 
-- bound records last only as long as their supporting records. When supporting records changes, then bound records changes acordingly, replacing any previously bound records.
+- bound records last only as long as their supporting records. When supporting records changes, then bound records changes accordingly, replacing any previously bound records.
 
 - committed records persist past the lifetime of their supporting records. When supporting records change, then a new record is committed, leaving any previously committed records still intact.
 
@@ -28,4 +28,4 @@ There are three actions in Eve: `match`, `bind`, and `commit`.
 
 ## See Also
 
-[match](../match) | [bind](../bind) | [commit](../commit)
+[search](../search) | [bind](../bind) | [commit](../commit)

--- a/src/handbook/blocks.md
+++ b/src/handbook/blocks.md
@@ -52,7 +52,7 @@ Blocks automatically keep bound and committed records up-to-date with matched re
 
 ## Tips
 
-Althgouth they are similar, it's important not to think of blocks like functions in other languages. Blocks don't have a name, and you don't "call" them like you do functions. Instead, you "use" a block by creating the records for which it searches.
+Although they are similar, it's important not to think of blocks like functions in other languages. Blocks don't have a name, and you don't "call" them like you do functions. Instead, you "use" a block by creating the records for which it searches.
 
 Likewise, there is no "main" block. Since Eve is declarative and there is no order, there is no particular starting point for a program. As a close analog, any block that does not search for records will execute when the program starts. For instance:
 
@@ -62,11 +62,11 @@ commit
   [#student name: "Ingrid"]
 ```
 
-This block has no `search` action, so it doesn't depend on any other recrods. Thus, it can be viewed as a "root" of the program. A program may contain many such roots.
+This block has no `search` action, so it doesn't depend on any other records. Thus, it can be viewed as a "root" of the program. A program may contain many such roots.
 
 ## Examples
 
-A block with match and bind actions. The bind action adds the `#div` to the `@browser` database.
+A block with search and bind actions. The bind action adds the `#div` to the `@browser` database.
 
 ```eve
 search
@@ -76,7 +76,7 @@ bind @browser
   [#div text: name]
 ```
 
-A block with only a commit action: 
+A block with only a commit action:
 
 ```eve
 commit

--- a/src/handbook/ebnf.md
+++ b/src/handbook/ebnf.md
@@ -36,7 +36,7 @@ uuid ="⦑" (unicode - specials)  "⦒"
 ## Keywords and Identifiers
 
 ```ebnf
-match = "match";
+search = "search";
 action = "bind" | "commit";
 if = "if";
 then = "then";
@@ -44,7 +44,7 @@ else = "else";
 is = "is";
 not = "not";
 none = "none";
-keyword = match | action | if | then | else | boolean | is | not | none
+keyword = search | action | if | then | else | boolean | is | not | none
 non-special-non-numeric = non-special - numeric
 identifier = (non-special-non-numeric {non-special}) - keyword - "```";
 ```
@@ -126,7 +126,7 @@ if-statement = (identifier | binding-group) whitespace+ equality whitespace+
 
 ```ebnf
 database-declaration = name | "(" {name whitespace+} ")"
-match-section = match whitespace+ [database-declaration whitespace+] {statement whitespace}
+match-section = search whitespace+ [database-declaration whitespace+] {statement whitespace}
 action-section = action whitespace+ [database-declaration whitespace+] {action-statement whitespace}
 section = match-sectiong | action-section
 ```

--- a/src/handbook/merge.md
+++ b/src/handbook/merge.md
@@ -25,7 +25,7 @@ record <- [attribute: value, ... ]
 Match a record and merge a record into it.
 
 ```eve
-match
+search
   celia = [@Celia]
 bind
   celia <- [#student grade: 10, school: "East"]


### PR DESCRIPTION
And also correct a few other typos I saw along the way.
