### PR TITLE
Fix typos

### DIFF
--- a/src/handbook/bind.md
+++ b/src/handbook/bind.md
@@ -52,7 +52,7 @@ commit @browser
   [#div text: seconds]
 ```
 
-Comapred to the previous block, we only changed `bind` to `commit`. When you run this block, at first you'll see a single message like before. However, you'll notice that messages begin to accumulate every second. Unlike with bind, **committed records persist in the database until they are intentionally removed**.
+Compared to the previous block, we only changed `bind` to `commit`. When you run this block, at first you'll see a single message like before. However, you'll notice that messages begin to accumulate every second. Unlike with bind, **committed records persist in the database until they are intentionally removed**.
  
 To make things very concrete, we can actually mimic the behavior of a bind using two blocks that commit. We've already got the first one (the one just above), that commits messages to `@browser`. Now all we need is a second block, one that removes old committed messages from `@browser`:
 

--- a/src/handbook/blocks.md
+++ b/src/handbook/blocks.md
@@ -62,7 +62,7 @@ commit
   [#student name: "Ingrid"]
 ```
 
-This block has no `search` action, so it doesn't depend on any other recrods. Thus, it can be viewed as a "root" of the program. A program may contain many such roots.
+This block has no `search` action, so it doesn't depend on any other records. Thus, it can be viewed as a "root" of the program. A program may contain many such roots.
 
 ## Examples
 

--- a/src/handbook/commit.md
+++ b/src/handbook/commit.md
@@ -20,7 +20,7 @@ commit @database1, ..., @databaseN
 
 ## Description
 
-`commmit` updates or creates new records that persist in a database until they are intentionally removed. If supporting records change or are removed, the original committed records remain in tact, and can still be searched by other blocks. By default, committed records are directed to a local database.
+`commit` updates or creates new records that persist in a database until they are intentionally removed. If supporting records change or are removed, the original committed records remain in tact, and can still be searched by other blocks. By default, committed records are directed to a local database.
 
 `commit @database1, ..., @databaseN` directs committed records one or more databases.
 
@@ -50,7 +50,7 @@ commit @browser
   [#div text: seconds]
 ```
 
-Comapred to the previous block, we only changed `bind` to `commit`. When you run this block, at first you'll see a single message like before. However, you'll notice that messages begin to accumulate every second. Unlike with bind, **committed records persist in the database until they are intentionally removed**.
+Compared to the previous block, we only changed `bind` to `commit`. When you run this block, at first you'll see a single message like before. However, you'll notice that messages begin to accumulate every second. Unlike with bind, **committed records persist in the database until they are intentionally removed**.
  
 To make things very concrete, we can actually mimic the behavior of a bind using two blocks that commit. We've already got the first one (the one just above), that commits messages to `@browser`. Now all we need is a second block, one that removes old committed messages from `@browser`:
 

--- a/src/handbook/string-interpolation.md
+++ b/src/handbook/string-interpolation.md
@@ -22,7 +22,7 @@ injects the value of an attribute or variable into a string
 
 String interpolation works element-wise on its input. This means the string will be repeated for every unique value in `variable`. 
 
-Multiple variables can be interpolatd into strings. If the variables have no relation to eacother (i.e. they are not joined or part of the same record), then string interpolation is applied to the cartesian product of the sets. 
+Multiple variables can be interpolated into strings. If the variables have no relation to eacother (i.e. they are not joined or part of the same record), then string interpolation is applied to the cartesian product of the sets. 
 
 ## Examples
 


### PR DESCRIPTION
Many small changes, such as:

comapred --> compared
commmit --> commit
etc