### PR TITLE
String docs

### DIFF
--- a/guides/style.md
+++ b/guides/style.md
@@ -94,9 +94,9 @@ value = if bar then baz
         else baz3
 
 // Okay, especially if the branch is long
-value = if [#long-record attr1 attr2 attr3] 
+value = if [#long-record attr1 attr2 attr3]
           then baz
-        if [#long-record2 attr1 attr2 attr3] 
+        if [#long-record2 attr1 attr2 attr3]
           then baz2
         else baz3
 
@@ -120,20 +120,20 @@ Nested records should appear on their own line if you are nesting more than one.
 [#div text: "hello", children: [#div text: "world"]]
 
 // More readable
-[#div text: "hello", children: 
+[#div text: "hello", children:
   [#div text: "world"]]
 
 // Also good
-[#div children: 
+[#div children:
   [#div text: "div1"]
   [#div text: "div2" children:
-    [#div text: "div3"]]]  
+    [#div text: "div3"]]]
 
 // Not good
 [#div children: [#div text: "div2"] [#div text: "div2"]]
 
 // Also not good
-[#div children: 
+[#div children:
   [#div text: "world"], text: "hello"]
 ```
 
@@ -152,7 +152,7 @@ search @schoolDB
   schools.name = student.school
 
 bind @browser
-  [#div text: students.name] 
+  [#div text: students.name]
 
 commit
   [#new-record]
@@ -167,7 +167,7 @@ search @schoolDB
   schools = [#school]
   schools.name = student.school
 bind @browser
-  [#div text: students.name] 
+  [#div text: students.name]
 commit
   [#new-record]
 ```

--- a/handbook/strings/convert.md
+++ b/handbook/strings/convert.md
@@ -1,0 +1,54 @@
+---
+menu:
+  main:
+    parent: "Strings"
+title: "convert"
+---
+
+# convert
+
+converts a number into a string or vice versa.
+
+## Syntax
+
+```eve
+converted = convert[value, to]
+```
+
+## Attributes
+
+- `converted` - the resulting converted value
+- `value` - the value to be converted
+- `to` - a string that specifies the target value type, either "number" or "string"
+
+## Description
+
+`converted = convert[value, to]` converts `value` from a number to a string if `to` is set to `"string"`, or if `to` is set to `"number"` converts `value` from a string to a number.
+
+## Examples
+
+Convert a string to a number, multiplies it
+
+```eve
+search
+  x = convert[value: "1", to: "number"]
+  y = x * 2
+  
+bind @browser
+  [#div text: y]
+```
+
+Convert a number to a string, gets its length
+
+```eve
+search
+  str = convert[value: "42", to: "number"]
+  c = length[str]
+  
+bind @browser
+  [#div text: c]
+```
+
+## See Also
+
+[concat](../concat) | [join](../join) | [char-at](../char-at) | [substring](../substring) | [length](../length) | [replace](../replace) | [split](../split)

--- a/handbook/strings/find.md
+++ b/handbook/strings/find.md
@@ -1,0 +1,67 @@
+---
+menu:
+  main:
+    parent: "Strings"
+title: "find"
+---
+
+# find
+
+finds a string within a larger string (optinally case-sensitive), starting from the starting index (which defaults to 1).
+
+## Syntax
+
+```eve
+(string-position, result-index) = find[text, subtext, case-sensitive, from]
+```
+
+## Attributes
+
+- `text` - the larger text to be searched within
+- `subtext` - the string to find in `text`
+- `case-sensitive` - the recovered tokens after the split
+- `string-position` - the positions of the occurences of `subtext` in the original text
+- `result-index` - the index of this occurence in all occurences of `subtext` in `text`
+
+## Description
+
+`(string-position, result-index) = find[text, subtext, case-sensitive, from]` finds all the occurences of `subtext` in `text`, by default case-insensitively. For each match, it returns the position in the string (index starting at one) and the number of the match (for instance, the first match is one, the second match is two). If `from` is specified, it starts the search at that index, inclusively.
+
+## Examples
+
+Find all occurences of the string "hello" in `str` (case-insensitive, starting at the first index)
+
+```eve
+search
+  str = "ahellobhellochello"
+  (a, b) = find[text: str, subtext: "hello"]
+
+bind @browser
+  [#div text: "{{a}}, {{b}}"]
+```
+
+Find all occurences of a capital 'X' in a string
+
+```eve
+search
+  str = "xxxXxxXxXXX"
+  (a, b) = find[text: str, subtext: "X", case-sensitive: true]
+
+bind @browser
+  [#div text: "{{a}}, {{b}}"]
+```
+
+Find occurences of 'X' after the first one
+
+```eve
+search
+  str = "xxxXxxXxXXX"
+  (a, b) = find[text: str, subtext: "X", case-sensitive: true, from: 5]
+
+bind @browser
+  [#div text: "{{a}}, {{b}}"]
+```
+
+## See Also
+
+[concat](../concat) | [join](../join) | [char-at](../char-at) | [substring](../substring) | [length](../length) | [replace](../replace) | [split](../split)

--- a/handbook/strings/index.md
+++ b/handbook/strings/index.md
@@ -11,3 +11,6 @@ weight: 3
 - [split](split) - split a string into tokens
 - [join](join) - join tokens into a string
 - [length](length) - return the length of a string
+- [substring](substring) - return a substring of another string
+- [find](find) - return a substring of another string
+- [convert](convert) - return a substring of another string

--- a/handbook/strings/split.md
+++ b/handbook/strings/split.md
@@ -17,7 +17,7 @@ splits a string at the given delimiter
 
 ## Attributes
 
-- `text` - the text to be split 
+- `text` - the text to be split
 - `by` - the delimiter at which to split the text. An empty string will split the text at every character.
 - `token` - the recovered tokens after the split
 - `index` - the indices of the tokens in the original text  

--- a/handbook/strings/substring.md
+++ b/handbook/strings/substring.md
@@ -1,0 +1,44 @@
+---
+menu:
+  main:
+    parent: "Strings"
+title: "substring"
+---
+
+# substring
+
+gets the substring of the provided string starting at the specified index (or 1 if not specified) and ending at the other specified index (required).
+
+## Syntax
+
+```eve
+substr = substring[text, from, to]
+```
+
+## Attributes
+
+- `text` - the text to substring
+- `to` - the maximum index of the substring, inclusive.
+- `from` - the starting index of the substring, starting at one, inclusive
+- `substr` - the final substring
+
+## Description
+
+`substr = substring[text, from, to]` gets a substring of `text` stretching from `from` to `to`, inclusively on both sides: [from, to].
+**Note:** String indexing starts at one. If you are an experienced programmer, this might trip you up.
+
+## Examples
+
+Extracts the word "hello" from the string
+
+```eve
+search
+  greeting = substring[text: "ahellob", from: 2, to: 6]
+
+bind @browser
+  [#div text: greeting]
+```
+
+## See Also
+
+[concat](../concat) | [join](../join) | [char-at](../char-at) | [find](../find) | [length](../length) | [replace](../replace) | [split](../split)

--- a/handbook/strings/urlencode.md
+++ b/handbook/strings/urlencode.md
@@ -1,0 +1,41 @@
+---
+menu:
+  main:
+    parent: "Strings"
+title: "urlencode"
+---
+
+# urlencode
+
+the urlencoded, websafe, version of a string.
+
+## Syntax
+
+```eve
+safe = urlencode[text]
+```
+
+## Attributes
+
+- `text` - the string to be encoded
+- `safe` - a url-safe, encoded string
+
+## Description
+
+`safe = urlencode[text]` converts `text` into a url-safe string (e.g. replacing a space with `%20`), returning it to `safe`.
+
+## Examples
+
+Urlencodes a mathematical expression
+
+```eve
+search
+  z = urlencode[text: "x * 2"]
+  
+bind @browser
+  [#div text: z]
+```
+
+## See Also
+
+[concat](../concat) | [join](../join) | [char-at](../char-at) | [substring](../substring) | [length](../length) | [replace](../replace) | [split](../split)


### PR DESCRIPTION
For one of my Eve projects, a calculator, I realized I needed more string manipulation providers then are present in the master branch, so I switched to the runtime-refactor branch and found more string manipulation providers sitting, undocumented, in the codebase. I went ahead and documented them. I will proceed (in another pull request) to add more functions, such as char-at.